### PR TITLE
Sort special characters before numbers

### DIFF
--- a/casefolded/natsort.go
+++ b/casefolded/natsort.go
@@ -73,9 +73,7 @@ func NaturalLess(str1, str2 string) bool {
 
 		dig1, dig2 := isDigit(c1), isDigit(c2)
 		switch {
-		case dig1 != dig2: // Digits before other characters.
-			return dig1 // True if LHS is a digit, false if the RHS is one.
-		case !dig1: // && !dig2, because dig1 == dig2
+		case !dig1 || !dig2:
 			// For ASCII it suffices to normalize letters to upper-case,
 			// because upper-cased ASCII compares lexicographically.
 			// Note: this does not account for regional special cases
@@ -132,9 +130,7 @@ hasUnicode:
 
 		dig1, dig2 := isDigit(c1), isDigit(c2)
 		switch {
-		case dig1 != dig2: // Digits before other characters.
-			return dig1 // True if LHS is a digit, false if the RHS is one.
-		case !dig1: // && !dig2, because dig1 == dig2
+		case !dig1 || !dig2:
 			idx1 += delta1
 			idx2 += delta2
 			// Fast path: identical runes are equal.

--- a/casefolded/natsort_test.go
+++ b/casefolded/natsort_test.go
@@ -94,6 +94,9 @@ func TestNaturalLess(t *testing.T) {
 		// Kelvin sign followed by numeric comparison
 		{"\u212alm2", "Klm10", true},
 		{"Klm01", "\u212alm2", true},
+		// Special characters
+		{"!", "1", true},
+		{"!", "\u212alm2", true},
 	}
 	for _, v := range testset {
 		if got := NaturalLess(v.s1, v.s2); got != v.less {

--- a/natsort.go
+++ b/natsort.go
@@ -30,9 +30,7 @@ func NaturalLess(str1, str2 string) bool {
 		c1, c2 := str1[idx1], str2[idx2]
 		dig1, dig2 := isDigit(c1), isDigit(c2)
 		switch {
-		case dig1 != dig2: // Digits before other characters.
-			return dig1 // True if LHS is a digit, false if the RHS is one.
-		case !dig1: // && !dig2, because dig1 == dig2
+		case !dig1 || !dig2:
 			// UTF-8 compares bytewise-lexicographically, no need to decode
 			// codepoints.
 			if c1 != c2 {

--- a/natsort_test.go
+++ b/natsort_test.go
@@ -51,6 +51,8 @@ func TestNaturalLess(t *testing.T) {
 		//
 		{"082", "83", true},
 		{"9a", "083a", true},
+		// Special characters
+		{"!", "1", true},
 	}
 	for _, v := range testset {
 		if got := NaturalLess(v.s1, v.s2); got != v.less {


### PR DESCRIPTION
Resolves #4. As per the issue, I'm not sure if this behaviour was intended, but for our usage we need special characters to be sorted before numbers.